### PR TITLE
Raise error if no invoice is found by number

### DIFF
--- a/lib/ruconomic/api/invoice.rb
+++ b/lib/ruconomic/api/invoice.rb
@@ -204,6 +204,8 @@ module Ruconomic
           message.add 'number', number
         end
 
+        raise "Invoice not found" if response.to_hash[:invoice_find_by_number_response].nil?
+
         response.to_hash[:invoice_find_by_number_response][:invoice_find_by_number_result][:number]
       end
 

--- a/lib/ruconomic/api/invoice.rb
+++ b/lib/ruconomic/api/invoice.rb
@@ -204,7 +204,7 @@ module Ruconomic
           message.add 'number', number
         end
 
-        raise "Invoice not found" if response.to_hash[:invoice_find_by_number_response].nil?
+        return nil if response.to_hash[:invoice_find_by_number_response].nil?
 
         response.to_hash[:invoice_find_by_number_response][:invoice_find_by_number_result][:number]
       end

--- a/lib/ruconomic/api/invoice.rb
+++ b/lib/ruconomic/api/invoice.rb
@@ -204,9 +204,7 @@ module Ruconomic
           message.add 'number', number
         end
 
-        return nil if response.to_hash[:invoice_find_by_number_response].nil?
-
-        response.to_hash[:invoice_find_by_number_response][:invoice_find_by_number_result][:number]
+        response.to_hash.dig(:invoice_find_by_number_response, :invoice_find_by_number_result, :number)
       end
 
       # Returns an array with handles for the invoices corresponding to the given invoice numbers. If a invoice with a given number does not exist then the array contains nothing at that index.

--- a/ruconomic.gemspec
+++ b/ruconomic.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "curb"
   spec.add_runtime_dependency "libxml-ruby"
+  spec.add_runtime_dependency "ruby_dig"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
e-conomic returns empty `invoice_find_by_number_response` if no invoice found. 