### PR TITLE
show the full fault response when errors

### DIFF
--- a/lib/ruconomic/fault.rb
+++ b/lib/ruconomic/fault.rb
@@ -1,17 +1,14 @@
 module Ruconomic
   class Fault < StandardError
-    attr_reader :code, :reason, :details
-    
-    def initialize(code, reason, details)
-      super(reason)
-      @code = code
-      @reason = reason
-      @details = details
+    attr_reader :fault
+
+    def initialize(fault)
+      super(fault[:code] || fault[:faultcode])
+      @fault = fault
     end
-    
+
     def to_s
-        "Ruconomic::Fault { :code => '#{@code}', :reason => '#{@reason}', :details => '#{@details}' }"
-    end     
-    
+      "Ruconomic::Fault #{fault.to_s}"
+    end
   end
 end

--- a/lib/ruconomic/web_service.rb
+++ b/lib/ruconomic/web_service.rb
@@ -39,7 +39,7 @@ module Ruconomic
         if @@curl.response_code != 200
           h = response.to_hash || {}
           fault = h[:fault]
-          raise Ruconomic::Fault.new(fault[:faultcode],fault[:faultstring],fault[:details]) if fault
+          raise Ruconomic::Fault.new(fault) if fault
         end
         LibXML::XML::Namespace.new(response.root, nil, "http://e-conomic.com")
         response.root.namespaces.default_prefix = "dns"


### PR DESCRIPTION
it seems like e-conomic SOAP API is inconsistent in the error codes as well,
so going for a more broad error output than the more precise old version