### PR TITLE
Better exception message if no result on Invoice_GetData

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The ruconomic gem provides a lightweight, speedy and easy-to-use ruby wrapper for the [e-conomic](http://www.e-conomic.com) SOAP web service - it will build, parse and transport some XML and little else. For a more full SOAPedelic experience, have a look at [rconomic](https://github.com/lokalebasen/rconomic).
 
-This gem is intended to be a crowd source project. The [e-conomic webservice](https://api.e-conomic.com/secure/api1/EconomicWebService.asmx) implements ~1500 operations(!), and all those operations are mapped to ruby classes and methods under ```lib/ruconomic/api``` - but not fully implemented. As always, the best way to understand is to [browse the source](https://github.com/coherify/ruconomic/tree/master/lib/ruconomic/api).
+This gem is intended to be a crowd source project. The [e-conomic webservice](https://api.e-conomic.com/secure/api1/EconomicWebService.asmx) implements ~1500 operations(!), and all those operations are mapped to ruby classes and methods under `lib/ruconomic/api` - but not fully implemented. As always, the best way to understand is to [browse the source](https://github.com/coherify/ruconomic/tree/master/lib/ruconomic/api).
 
 So, the idea is that we [add functionality](https://github.com/coherify/ruconomic#contributing) as needed.
 
@@ -71,7 +71,11 @@ end
 
 ## Documentation
 
-You can find the latest API documentation at [http://rdoc.info/github/coherify/ruconomic/index](http://rdoc.info/github/coherify/ruconomic/index) or generate your own copy with ```bundle install && bundle exec yardoc``` after cloning the repository.
+You can find the latest API documentation at http://rdoc.info/github/coherify/ruconomic/index or generate your own copy with `bundle install && bundle exec yardoc` after cloning the repository.
+
+## Testing
+
+Run the minitest suite with `bundle exec rake`
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
 require "bundler/gem_tasks"
 
+FileList["lib/tasks/*.rake"].each do |task|
+  import task
+end

--- a/lib/ruconomic/api/cash_book.rb
+++ b/lib/ruconomic/api/cash_book.rb
@@ -39,8 +39,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:cash_book_get_data_response] \
-          [:cash_book_get_data_result]
+        response.fetch(:cash_book_get_data_response, :cash_book_get_data_result)
       end
 
       # Returns cash book data objects for a given set of cash book handles.
@@ -62,7 +61,7 @@ module Ruconomic
       def self.get_all
         response = invoke('CashBook_GetAll')
 
-        response.to_hash[:cash_book_get_all_response][:cash_book_get_all_result]
+        response.fetch(:cash_book_get_all_response, :cash_book_get_all_result)
       end
 
       # Returns a handle for the cash book with the given number.
@@ -151,8 +150,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:cash_book_get_entries_response] \
-          [:cash_book_get_entries_result]
+        response.fetch(:cash_book_get_entries_response, :cash_book_get_entries_result)
       end
 
       # Delete all entries from a cash book. Action that cannot be undone.

--- a/lib/ruconomic/api/current_invoice.rb
+++ b/lib/ruconomic/api/current_invoice.rb
@@ -279,8 +279,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:current_invoice_get_text_line1_response] \
-          [:current_invoice_get_text_line1_result]
+        response.fetch(:current_invoice_get_text_line1_response, :current_invoice_get_text_line1_result)
       end
 
       # Set the primary line of a current invoice.
@@ -296,7 +295,7 @@ module Ruconomic
           message.add 'value', text
         end
 
-        response.to_hash[:current_invoice_set_text_line1]
+        response.fetch(:current_invoice_set_text_line1)
       end
 
       # Gets the secondary line of text of a current invoice.
@@ -324,7 +323,7 @@ module Ruconomic
           message.add 'value', text
         end
 
-        response.to_hash[:current_invoice_set_text_line2]
+        response.fetch(:current_invoice_set_text_line2)
       end
 
       # Gets the other reference of a current invoice.
@@ -574,7 +573,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:current_invoice_get_data_response][:current_invoice_get_data_result]
+        response.fetch(:current_invoice_get_data_response, :current_invoice_get_data_result)
       end
 
       # Returns current invoice data objects for a given set of current invoice handles.
@@ -600,7 +599,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:current_invoice_create_response][:current_invoice_create_result][:id]
+        response.fetch(:current_invoice_create_response, :current_invoice_create_result, :id)
       end
 
       # Returns handles for all current invoices.
@@ -610,7 +609,7 @@ module Ruconomic
       def self.get_all
         response = invoke('CurrentInvoice_GetAll')
 
-        response.to_hash[:current_invoice_get_all_response][:current_invoice_get_all_result]
+        response.fetch(:current_invoice_get_all_response, :current_invoice_get_all_result)
       end
 
       # Returns handles for the current invoices which have the given employee as OurReference.
@@ -683,7 +682,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:current_invoice_book_response][:current_invoice_book_result][:number]
+        response.fetch(:current_invoice_book_response, :current_invoice_book_result, :number)
       end
 
       # Books a current invoice.
@@ -710,7 +709,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:current_invoice_delete_response]
+        response.fetch(:current_invoice_delete_response)
       end
 
       # Gets handles for the lines of a current invoice.
@@ -1111,7 +1110,7 @@ module Ruconomic
           message.add 'value', due_date
         end
 
-        response.to_hash[:current_invoice_set_due_date_response]
+        response.fetch(:current_invoice_set_due_date_response)
       end
 
       # Gets the currency of a current invoice.

--- a/lib/ruconomic/api/debtor.rb
+++ b/lib/ruconomic/api/debtor.rb
@@ -307,8 +307,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:debtor_update_from_data_response] \
-          [:debtor_update_from_data_result][:number]
+        response.fetch(:debtor_update_from_data_response, :debtor_update_from_data_result, :number)
       end
 
       # Returns a debtor data object for a given debtor.
@@ -323,7 +322,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:debtor_get_data_response][:debtor_get_data_result]
+        response.fetch(:debtor_get_data_response, :debtor_get_data_result)
       end
 
       # Returns debtor data objects for a given set of debtor handles.
@@ -828,7 +827,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:debtor_get_term_of_payment_response][:debtor_get_term_of_payment_result][:id]
+        response.fetch(:debtor_get_term_of_payment_response, :debtor_get_term_of_payment_result, :id)
       end
 
       # Sets the layout of a debtor. The value may be omitted.
@@ -855,7 +854,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:debtor_get_layout_response][:debtor_get_layout_result][:id]
+        response.fetch(:debtor_get_layout_response, :debtor_get_layout_result, :id)
       end
 
       # Gets a handle for the attention of a debtor.
@@ -971,7 +970,7 @@ module Ruconomic
           message.add 'vatZone', vat_zone
         end
 
-        response.to_hash[:debtor_create_response][:debtor_create_result][:number]
+        response.fetch(:debtor_create_response, :debtor_create_result, :number)
       end
 
       # Return handles for all debtors

--- a/lib/ruconomic/api/invoice.rb
+++ b/lib/ruconomic/api/invoice.rb
@@ -331,7 +331,16 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:invoice_get_data_response][:invoice_get_data_result]
+        response = response.to_hash
+
+        if response[:invoice_get_data_response] && response[:invoice_get_data_response][:invoice_get_data_result]
+          response[:invoice_get_data_response][:invoice_get_data_result]
+        else
+          fault = {
+            code: "Invoice_GetData_no_result",
+            message: "No result in response: #{response.inspect}"
+          }
+          raise Fault, fault
       end
 
       # Returns invoice data objects for a given set of invoice handles.

--- a/lib/ruconomic/api/invoice.rb
+++ b/lib/ruconomic/api/invoice.rb
@@ -192,7 +192,7 @@ module Ruconomic
       def self.get_all
         response = invoke('Invoice_GetAll')
 
-        response.to_hash[:invoice_get_all_response][:invoice_get_all_result]
+        response.fetch(:invoice_get_all_response, :invoice_get_all_result)
       end
 
       # Returns a handle for the invoice with the given number.
@@ -304,7 +304,7 @@ module Ruconomic
           end
         end
 
-        response.to_hash[:invoice_get_pdf_response][:invoice_get_pdf_result]
+        response.fetch(:invoice_get_pdf_response, :invoice_get_pdf_result)
       end
 
       # Gets an OIO XML string representing an invoice.
@@ -331,16 +331,7 @@ module Ruconomic
           end
         end
 
-        response = response.to_hash
-
-        if response[:invoice_get_data_response] && response[:invoice_get_data_response][:invoice_get_data_result]
-          response[:invoice_get_data_response][:invoice_get_data_result]
-        else
-          fault = {
-            code: "Invoice_GetData_no_result",
-            message: "No result in response: #{response.inspect}"
-          }
-          raise Fault, fault
+        response.fetch(:invoice_get_data_response, :invoice_get_data_result)
       end
 
       # Returns invoice data objects for a given set of invoice handles.

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,8 @@
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/test_*.rb']
+end
+desc "Run tests"
+
+task default: :test

--- a/test/soap/test_document.rb
+++ b/test/soap/test_document.rb
@@ -1,0 +1,52 @@
+require "minitest/autorun"
+require "ruconomic/soap/document"
+
+module Ruconomic
+  module SOAP
+    describe Document do
+      describe "fetch" do
+        it "gets existing subnode" do
+          node = Node.new("foo")
+          node.add("bar", "baz")
+          document = Document.new
+          document << node
+
+          assert_equal("baz", document.fetch(:foo, :bar))
+          assert_equal({bar: "baz"}, document.fetch(:foo))
+        end
+
+        it "returns nil if it is the last path part that does not match" do
+          node = Node.new("foo")
+          node.add("bar", "baz")
+          document = Document.new
+          document << node
+
+          assert_nil(document.fetch(:bogus))
+          assert_nil(document.fetch(:foo, :bogus))
+        end
+
+        it "errors on missing key" do
+          node = Node.new("foo")
+          node.add("bar", "baz")
+          document = Document.new
+          document << node
+
+          assert_raises(Document::KeyError) do
+            document.fetch(:bogus, :foo)
+          end
+        end
+
+        it "errors on middle value not being a hash" do
+          node = Node.new("foo")
+          node.add("bar", "baz")
+          document = Document.new
+          document << node
+
+          assert_raises(Document::KeyError) do
+            document.fetch(:foo, :bar, :baz)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometime the `Invoice_GetData` endpoint returns something that is not an `invoice_get_data_result`, which will return in a ``undefined method `[]' for nil:NilClass``.

This PR adds better debug info by providing the response hash in the exception message.